### PR TITLE
Update v1.1.3

### DIFF
--- a/org.mapeditor.Tiled.json
+++ b/org.mapeditor.Tiled.json
@@ -40,8 +40,8 @@
       "sources": [
         {
           "type": "archive",
-          "url": "https://github.com/bjorn/tiled/archive/v1.1.2.tar.gz",
-          "sha256": "8003956759636a0230e59ce4cb7cfd917e27270a23aeab8b02d181d040609c50"
+          "url": "https://github.com/bjorn/tiled/archive/v1.1.3.tar.gz",
+          "sha256": "13a4861b9c0f68936ee1f4aa463674bb4729b2574946934994d6fac3b6a17d21"
         }
       ]
     }


### PR DESCRIPTION

    Fixed crash when removing a tileset referenced by multiple objects
    Fixed crash on paste when it introduced more than one new tileset
    Fixed Invert Selection for non-infinite maps
    Fixed Select All to not select objects on locked layers
    Fixed logic determining the tilesets used by a tile layer
    Fixed copy/paste changing object order (#1896)
    Fixed tileset getting loaded twice when used by the map and a template
    Fixed repainting issues on undo/redo for new maps (#1887)
    JSON plugin: Fixed loading of infinite maps using CSV tile layer format (#1878)
    Linux: Updated AppImage to Qt 5.9.4
    Updated Hungarian, Japanese, Norwegian Bokmål, Portuguese and Ukrainian translations