### PR TITLE
Build using Qbs

### DIFF
--- a/org.mapeditor.Tiled.json
+++ b/org.mapeditor.Tiled.json
@@ -19,8 +19,30 @@
   ],
   "modules": [
     {
+      "name": "qbs",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://download.qt.io/official_releases/qbs/1.20.0/qbs-src-1.20.0.tar.gz",
+          "sha256": "44961a4bb61580ae821aaf25ebb5a5737bd8fb79ec0474aa2592cdd45cc5171f"
+        },
+        {
+          "type": "script",
+          "dest-filename": "configure",
+          "commands": [
+            "qmake QBS_INSTALL_PREFIX=/app CONFIG+=qbs_enable_project_file_updates qbs.pro"
+          ]
+        }
+      ]
+    },
+    {
       "name": "tiled",
-      "buildsystem": "qmake",
+      "buildsystem": "simple",
+      "build-commands": [
+        "qbs setup-toolchains --detect",
+        "qbs --no-install qbs.installPrefix:/app",
+        "qbs install --no-build --install-root /"
+      ],
       "config-opts": [
         "CONFIG+=release"
       ],


### PR DESCRIPTION
Using qmake to build Tiled is deprecated (closes #10), this updates it to use Qbs. This is based on [another app that uses QBS to build](https://github.com/flathub/flathub/pull/654/files).