### PR TITLE
Properly make Qbs produce optimized builds

### DIFF
--- a/org.mapeditor.Tiled.json
+++ b/org.mapeditor.Tiled.json
@@ -40,11 +40,8 @@
       "buildsystem": "simple",
       "build-commands": [
         "qbs setup-toolchains --detect",
-        "qbs --no-install qbs.installPrefix:/app",
-        "qbs install --no-build --install-root /"
-      ],
-      "config-opts": [
-        "CONFIG+=release"
+        "qbs --no-install config:release qbs.installPrefix:/app ",
+        "qbs install --no-build --install-root / config:release"
       ],
       "post-install": [
         "sed -i 's/application-x-tiled/org.mapeditor.Tiled-mimetype/g' /app/share/mime/packages/org.mapeditor.Tiled.xml",


### PR DESCRIPTION
This was noticed at https://github.com/flathub/org.mapeditor.Tiled/pull/11#discussion_r715583117: the way to ask for a release build is differs between Qbs and qmake. This properly makes builds optimized.