### PR TITLE
Update to Qt 6.4

### DIFF
--- a/org.mapeditor.Tiled.json
+++ b/org.mapeditor.Tiled.json
@@ -1,7 +1,7 @@
 {
   "app-id": "org.mapeditor.Tiled",
   "runtime": "org.kde.Platform",
-  "runtime-version": "5.15-21.08",
+  "runtime-version": "6.4",
   "sdk": "org.kde.Sdk",
   "command": "tiled",
   "rename-icon": "tiled",
@@ -21,18 +21,12 @@
   "modules": [
     {
       "name": "qbs",
+      "buildsystem": "cmake",
       "sources": [
         {
-          "type": "archive",
-          "url": "https://download.qt.io/official_releases/qbs/1.20.0/qbs-src-1.20.0.tar.gz",
-          "sha256": "44961a4bb61580ae821aaf25ebb5a5737bd8fb79ec0474aa2592cdd45cc5171f"
-        },
-        {
-          "type": "script",
-          "dest-filename": "configure",
-          "commands": [
-            "qmake QBS_INSTALL_PREFIX=/app CONFIG+=qbs_enable_project_file_updates qbs.pro"
-          ]
+          "type": "git",
+          "url": "https://github.com/qbs/qbs",
+          "tag": "v1.21.0"
         }
       ]
     },

--- a/org.mapeditor.Tiled.json
+++ b/org.mapeditor.Tiled.json
@@ -22,6 +22,7 @@
     {
       "name": "qbs",
       "buildsystem": "cmake",
+      "config-opts": ["-DWITH_TESTS=OFF"],
       "sources": [
         {
           "type": "git",

--- a/org.mapeditor.Tiled.json
+++ b/org.mapeditor.Tiled.json
@@ -28,7 +28,8 @@
           "url": "https://github.com/qbs/qbs",
           "tag": "v1.21.0"
         }
-      ]
+      ],
+      "cleanup": ["*"]
     },
     {
       "name": "tiled",


### PR DESCRIPTION
Also updated to Qbs 1.24.1 and build it with cmake instead of qmake.

This fails for me when locally running `flatpak-builder` with the following error:

```
ERROR: /usr/bin/g++ -O2 -Wall -Wextra -m64 -pipe -fexceptions -fvisibility=default -fPIC -DNDEBUG '-DQT_DISABLE_DEPRECATED_BEFORE=QT_VERSION_CHECK(5,15,0)' -DQT_NO_DEPRECATED_WARNINGS -DQT_NO_CAST_FROM_ASCII -DQT_NO_CAST_TO_ASCII -DQT_NO_FOREACH -DQT_NO_URL_CAST_FROM_STRING -DQT_WIDGETS_LIB -DQT_QML_LIB -DQT_QMLINTEGRATION_LIB -DQT_NETWORK_LIB -DQT_GUI_LIB -DQT_CORE_LIB -DQT_NO_DEBUG -I/run/build/tiled/src/tiledapp -I/run/build/tiled/src/tiled -I/run/build/tiled/src/qtsingleapplication/src -I/run/build/tiled/src/libtiled -I/run/build/tiled/release/tiled.1920fdf8/qt.headers -isystem/usr/include -isystem/usr/include/QtWidgets -isystem/usr/include/QtQml -isystem/usr/include/QtQmlIntegration -isystem/usr/include/QtNetwork -isystem/usr/include/QtGui -isystem/usr/include/QtCore -isystem/usr/mkspecs/linux-g++ -std=c++17 -o /run/build/tiled/release/tiled.1920fdf8/3a52ce780950d4d9/commandlineparser.cpp.o -c /run/build/tiled/src/tiledapp/commandlineparser.cpp

ERROR: In file included from /usr/include/QtCore/qnumeric.h:8,
                 from /usr/include/QtCore/qglobal.h:1405,
                 from /usr/include/QtCore/qcoreapplication.h:7,
                 from /usr/include/QtCore/QCoreApplication:1,
                 from /run/build/tiled/src/tiledapp/commandlineparser.h:24,
                 from /run/build/tiled/src/tiledapp/commandlineparser.cpp:22:
/usr/include/c++/12.1.0/cmath:45:15: fatal error: math.h: No such file or directory
   45 | #include_next <math.h>
      |               ^~~~~~~~
compilation terminated.
```

So far I have no idea how to resolve it.

Would close #20.