### PR TITLE
Update runtime version from 6.8 to 6.10

### DIFF
--- a/org.mapeditor.Tiled.json
+++ b/org.mapeditor.Tiled.json
@@ -75,7 +75,6 @@
                 {
                     "type": "git",
                     "url": "https://github.com/mapeditor/tiled.git",
-                    "branch": "1.11",
                     "commit": "b88da92804132eefb2e1dbb595a45bedc2f842e8",
                     "x-checker-data": {
                         "type": "anitya",

--- a/org.mapeditor.Tiled.json
+++ b/org.mapeditor.Tiled.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.mapeditor.Tiled",
     "runtime": "org.kde.Platform",
-    "runtime-version": "6.8",
+    "runtime-version": "6.10",
     "sdk": "org.kde.Sdk",
     "command": "tiled",
     "rename-icon": "tiled",

--- a/org.mapeditor.Tiled.json
+++ b/org.mapeditor.Tiled.json
@@ -75,7 +75,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/mapeditor/tiled.git",
-                    "commit": "93fb1e926556794ef3298f8c2b0916105dec47c2",
+                    "branch": "1.11",
+                    "commit": "b88da92804132eefb2e1dbb595a45bedc2f842e8",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 7298,

--- a/org.mapeditor.Tiled.json
+++ b/org.mapeditor.Tiled.json
@@ -52,8 +52,8 @@
                 {
                     "type": "git",
                     "url": "https://github.com/mapeditor/qaseprite",
-                    "tag": "1.0.1",
-                    "commit": "d2ba81f7d0c3329bfba015f9cb07527a9c9d743a"
+                    "tag": "1.0.3",
+                    "commit": "31528aa225789070ca2379e3b6b8b48061b1a440"
                 }
             ]
         },

--- a/org.mapeditor.Tiled.json
+++ b/org.mapeditor.Tiled.json
@@ -28,8 +28,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://github.com/qbs/qbs/archive/refs/tags/v2.6.1.tar.gz",
-                    "sha256": "bca391dd01168e075305baddcef7d4cf0a00b8543ee70b43942817db72d64904"
+                    "url": "https://github.com/qbs/qbs/archive/refs/tags/v3.1.2.tar.gz",
+                    "sha256": "33a981d51615a0115ecf8ec17b237c821cc403c613f4bc8623207d63a9183dc0"
                 }
             ],
             "cleanup": [


### PR DESCRIPTION
The 6.8 runtime is EOL.

Closes https://github.com/mapeditor/tiled/issues/4309